### PR TITLE
Enable ILM support in helm chart

### DIFF
--- a/charts/wsh-eck-stack/templates/ilm_job.yaml
+++ b/charts/wsh-eck-stack/templates/ilm_job.yaml
@@ -1,3 +1,4 @@
+{{- $root := . -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -17,4 +18,8 @@ spec:
         args:
         - /bin/sh
         - -c
-        - "sleep 30 ; curl -X PUT -u 'example-user:$2y$10$OrZF7nYE37TBmblHsKRTz.vsrzuI3PwpIzn94F5Hhl/gfW.CblhcG' -k 'https://elasticsearch-es-http.{{ .Release.Namespace }}.svc.cluster.local:9200/_ilm/policy/ilm_custom_policy' -H 'Content-Type: application/json' -d'{\"policy\":{\"phases\":{\"hot\":{\"actions\":{\"rollover\":{\"max_size\":\"{{ .Values.indexLifecycle.rollover }}\",\"max_age\":\"{{ .Values.indexLifecycle.deleteAfterDays }}\"}}},\"delete\":{\"min_age\":\"14d\",\"actions\":{\"delete\":{}}}}}}'; exit 0"
+        {{- range $username, $password := .Values.users }}
+        {{ if eq $username "example-user" }}    
+        - "sleep 60 ;curl -X PUT -u '{{ $username }}:{{ $password }}' -k 'https://elasticsearch-es-http.{{ $root.Release.Namespace }}.svc.cluster.local:9200/_ilm/policy/ilm_custom_policy' -H 'Content-Type: application/json' -d'{\"policy\":{\"phases\":{\"hot\":{\"actions\":{\"rollover\":{\"max_size\":\"{{ $root.Values.indexLifecycle.rollover }}\",\"max_age\":\"{{ $root.Values.indexLifecycle.deleteAfterDays }}\"}}},\"delete\":{\"min_age\":\"14d\",\"actions\":{\"delete\":{}}}}}}'; exit 0"
+        {{ end }}
+        {{ end }}

--- a/charts/wsh-eck-stack/templates/ilm_job.yaml
+++ b/charts/wsh-eck-stack/templates/ilm_job.yaml
@@ -19,7 +19,7 @@ spec:
         - /bin/sh
         - -c
         {{- range $username, $password := .Values.users }}
-        {{ if eq $username "example-user" }}    
+        {{ if eq $username "internal-api-user" }}    
         - "sleep 60 ;curl -X PUT -u '{{ $username }}:{{ $password }}' -k 'https://elasticsearch-es-http.{{ $root.Release.Namespace }}.svc.cluster.local:9200/_ilm/policy/ilm_custom_policy' -H 'Content-Type: application/json' -d'{\"policy\":{\"phases\":{\"hot\":{\"actions\":{\"rollover\":{\"max_size\":\"{{ $root.Values.indexLifecycle.rollover }}\",\"max_age\":\"{{ $root.Values.indexLifecycle.deleteAfterDays }}\"}}},\"delete\":{\"min_age\":\"14d\",\"actions\":{\"delete\":{}}}}}}'; exit 0"
         {{ end }}
         {{ end }}

--- a/charts/wsh-eck-stack/templates/ilm_job.yaml
+++ b/charts/wsh-eck-stack/templates/ilm_job.yaml
@@ -1,0 +1,20 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: imlpolicy
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  template:
+    metadata:
+      name: imlpolicy
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: post-install-job
+        image: "curlimages/curl:7.76.0"
+        args:
+        - /bin/sh
+        - -c
+        - "sleep 30 ; curl -X PUT -u 'example-user:$2y$10$OrZF7nYE37TBmblHsKRTz.vsrzuI3PwpIzn94F5Hhl/gfW.CblhcG' -k 'https://elasticsearch-es-http.{{ .Release.Namespace }}.svc.cluster.local:9200/_ilm/policy/ilm_custom_policy' -H 'Content-Type: application/json' -d'{\"policy\":{\"phases\":{\"hot\":{\"actions\":{\"rollover\":{\"max_size\":\"{{ .Values.indexLifecycle.rollover }}\",\"max_age\":\"{{ .Values.indexLifecycle.deleteAfterDays }}\"}}},\"delete\":{\"min_age\":\"14d\",\"actions\":{\"delete\":{}}}}}}'; exit 0"

--- a/charts/wsh-eck-stack/values.yaml
+++ b/charts/wsh-eck-stack/values.yaml
@@ -34,7 +34,7 @@ user_roles:
 # -> purge / delete logs to free up space after x days, 14 should be the default.
 indexLifecycle:
   rollover: 5GB
-  deleteAfterDays: 14 # example
+  deleteAfterDays: 14d # example
 
 # the frontend is automatically integrated into the upstream nginx
 kibana:


### PR DESCRIPTION
Enable ILM support in helm chart. 

The change has been testing for both ILM creation and update. 

* Used current elastic CRD name to refer elasticsearch service and if it's changing svc name need to be change in ilm_job.yaml
* At least one user needs to configure to auth elasticsearch service in iam_job.yaml and currently it uses example-user.  